### PR TITLE
fixed references in file to compile correctly

### DIFF
--- a/ProjectSource/Chapters/Chapter 4 - C# Part 2/listing4-11.cs
+++ b/ProjectSource/Chapters/Chapter 4 - C# Part 2/listing4-11.cs
@@ -29,12 +29,12 @@ class Test
 {
   static void Main(string[] args)
   {
-    MyIntCollection<int> ic = new MyIntCollection<int>();
-    c.Add(4);
-    c.Add(102);
+    MyCollection<int> ic = new MyCollection<int>();
+    ic.Add(4);
+    ic.Add(102);
 
 
-    MyStringCollection<int> sc = new MyStringCollection<int>();
+    MyCollection<string> sc = new MyCollection<string>();
     sc.Add("Mark");
     sc.Add("Mamone");
 


### PR DESCRIPTION
replaced reference to `MyStringCollection` and `MyIntCollection` with `MyCollection` and `c` with `ic` to fix compile errors