### PR TITLE
minor fixs to compile without errors

### DIFF
--- a/ProjectSource/Chapters/Chapter 4 - C# Part 2/listing4-14.cs
+++ b/ProjectSource/Chapters/Chapter 4 - C# Part 2/listing4-14.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 public class MyCollection
 {
@@ -22,7 +23,7 @@ class Test
   {
 
     MyCollection m = new MyCollection();
-    foreach (string s in MyCollection)
+    foreach (string s in m)
     {
       Console.Out.WriteLine(s);
     }


### PR DESCRIPTION
added required using statement and changed reference from `MyCollection` class to `m` instance of `MyCollection` to fix compile errors